### PR TITLE
zlib is guarded by macro

### DIFF
--- a/lib/libkafka_asio/detail/compression_gz.h
+++ b/lib/libkafka_asio/detail/compression_gz.h
@@ -10,6 +10,8 @@
 #ifndef COMPRESSION_GZ_H_0B410507_A88B_468B_A1EC_ABC8B9246F62
 #define COMPRESSION_GZ_H_0B410507_A88B_468B_A1EC_ABC8B9246F62
 
+#ifndef NO_ZLIB
+
 #if !defined(LIBKAFKAASIO_NO_COMPRESSION) \
  && !defined(LIBKAFKAASIO_NO_COMPRESSION_GZIP)
 
@@ -41,5 +43,6 @@ struct CompressionPolicy<constants::kCompressionGZIP>
 
 #include <libkafka_asio/detail/impl/compression_gz.h>
 
+#endif  // NO_ZLIP
 #endif  // GZIP compression not disabled?
 #endif  // COMPRESSION_GZ_H_0B410507_A88B_468B_A1EC_ABC8B9246F62

--- a/lib/libkafka_asio/detail/impl/compression_gz.h
+++ b/lib/libkafka_asio/detail/impl/compression_gz.h
@@ -10,6 +10,7 @@
 #ifndef COMPRESSION_GZ_H_4936268F_C651_4E32_A917_8AC05247B3DB
 #define COMPRESSION_GZ_H_4936268F_C651_4E32_A917_8AC05247B3DB
 
+#ifndef NO_ZLIB
 #include <zlib.h>
 
 #include <algorithm>
@@ -123,4 +124,5 @@ inline Bytes GZIPCompressionAlgorithm::Decompress(
 }  // namespace detail
 }  // namespace libkafka_asio
 
+#endif  // NO_ZLIB
 #endif  // COMPRESSION_GZ_H_4936268F_C651_4E32_A917_8AC05247B3DB


### PR DESCRIPTION
Summary:
- zlib is guarded by macro
Test plan:
- remove the zlib and cmake and make 
Reviewer:
@yecol 